### PR TITLE
feat: configurable policy bundle location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ vsa:
 	go run cmd/attestation.go vsa \
 		--artifact-digest "sha256:6c3bf887638f7c0d86731e6208befa1b439e465cb435465d982c50609553b514" \
         --artifact-uri "ghcr.io/liatrio/gh-trusted-builds-app" \
-        --policy-version "v1.1.1" \
+        --policy-url "https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.1.1/bundle.tar.gz" \
         --verifier-id "local-verifier"

--- a/README.md
+++ b/README.md
@@ -111,13 +111,15 @@ The following process is used to create a VSA:
 ##### Command Flags
 
 `--policy-url`: Location of policy bundle that will be used to determine VSA result.
-Absolute paths will be handled as http requests to download the bundle.
-Relative paths will be handled as local filepaths to an existing bundle.
+Supports http(s) urls for unauthenticated external downloads.
+Absolute and relative paths can be used for an existing, local bundle.
 
 Examples:
 
 - `https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.1.1/bundle.tar.gz`
 - `bundle.tar.gz`
+- `../bundle.tar.gz`
+- `/Users/myhome/bundle.tar.gz`
 
 `--verifier-id`: ID of entity verifying the policy for the VSA.
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,21 @@ $ ./attestation <attestation-type> [--flag]
 
 All attestation types may use or require these flags. 
 
-- `--fulcio-url`: The Fulcio CA url for keyless signing. Defaults to `https://fulcio.sigstore.dev`.
+`--fulcio-url`: The Fulcio CA url for keyless signing. Defaults to `https://fulcio.sigstore.dev`.
   Intended only for use with ambient providers like GitHub Actions, as there are no options for overriding the default OIDC settings.
-- `--rekor-url`: The transparency log URL. Defaults to `https://rekor.sigstore.dev`.
-- `--oidc-issuer-url`: Defaults to `https://oauth2.sigstore.dev/auth`.
-- `--oidc-client-id`: Defaults to `sigstore`.
-- `--artifact-uri`: **required** URI of the OCI artifact i.e., the subject of the attestation.
-  ex: `ghcr.io/liatrio/gh-trusted-builds-app`
-- `--artifact-digest`: **required**  digest of the OCI artifact.
-  Used for retrieving related artifact attestations, and marking the attestation subject.
-  ex: `sha256:60bcfdd293baac977357527bbd7ec2b5a7584ce276d33de0a4980c8ace6afd67`
+
+`--rekor-url`: The transparency log URL. Defaults to `https://rekor.sigstore.dev`.
+
+`--oidc-issuer-url`: Defaults to `https://oauth2.sigstore.dev/auth`.
+
+`--oidc-client-id`: Defaults to `sigstore`.
+
+`--artifact-uri`: **required** URI of the OCI artifact i.e., the subject of the attestation.
+ex: `ghcr.io/liatrio/gh-trusted-builds-app`
+
+`--artifact-digest`: **required**  digest of the OCI artifact.
+Used for retrieving related artifact attestations, and marking the attestation subject.
+ex: `sha256:60bcfdd293baac977357527bbd7ec2b5a7584ce276d33de0a4980c8ace6afd67`
 
 ### Attestations
 
@@ -81,7 +86,7 @@ The attestor expects to run inside a Git repository, as it will use the `HEAD` s
 For development, you can set the environment variable `GH_PR_ATTESTOR_SHA_OVERRIDE` to use a different SHA; however, this will not work in CI servers
 that set the `CI` environment variable.
 
-#### Environment Variables
+##### Environment Variables
 
 `GITHUB_TOKEN`: A GitHub token with access to read pull request information from repository of the commit.
 
@@ -103,15 +108,16 @@ The following process is used to create a VSA:
 1. Sign the attestation, using either the KMS or Fulcio methods configured via flags.
 1. Upload the VSA to Rekor.
 
-##### Environment Variables
-
-`GITHUB_TOKEN`: A GitHub token with access to read releases from https://github.com/liatrio/gh-trusted-builds-policy.
-
 ##### Command Flags
 
-`--policy-version`: GitHub release version of the governance policy to download from [gh-trusted-builds-policy](https://github.com/liatrio/gh-trusted-builds-policy).
-This is the OPA bundle that will be used at runtime to determine the VSA `verification_result`.
-ex: `v1.0.0`
+`--policy-url`: Location of policy bundle that will be used to determine VSA result.
+Absolute paths will be handled as http requests to download the bundle.
+Relative paths will be handled as local filepaths to an existing bundle.
+
+Examples:
+
+- `https://github.com/liatrio/gh-trusted-builds-policy/releases/download/v1.1.1/bundle.tar.gz`
+- `bundle.tar.gz`
 
 `--verifier-id`: ID of entity verifying the policy for the VSA.
 

--- a/internal/config/vsa.go
+++ b/internal/config/vsa.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -36,11 +37,17 @@ func NewVsaCommandOptions() *VsaCommandOptions {
 	}
 
 	c.fs = flag.NewFlagSet("vsa", flag.ContinueOnError)
-	c.fs.Func("policy-url", "URL to retrieve policy bundle. Absolute paths will be handled as HTTP requests. Relative paths will be handled as local filepaths.", func(s string) error {
+	c.fs.Func("policy-url", "Location of policy bundle that will be used to determine VSA result", func(s string) error {
 		u, err := url.Parse(s)
 		if err != nil {
 			return err
 		}
+
+		supportedSchemes := regexp.MustCompile("^https?$")
+		if u.IsAbs() && !supportedSchemes.MatchString(u.Scheme) {
+			return fmt.Errorf("unsupported scheme provided, should be one of http, https")
+		}
+
 		c.PolicyUrl = u
 		return nil
 	})

--- a/internal/intoto/attestation.go
+++ b/internal/intoto/attestation.go
@@ -58,7 +58,7 @@ func CreateVerificationSummaryAttestation(opts *config.VsaCommandOptions, passed
 		TimeVerified: timestamppb.Now(),
 		ResourceUri:  opts.ArtifactUri,
 		Policy: &vpb.VerificationSummary_Policy{
-			Uri: fmt.Sprintf("https://github.com/liatrio/gh-trusted-builds-policy/releases/download/%s/bundle.tar.gz", opts.PolicyVersion),
+			Uri: opts.PolicyUrl.String(),
 		},
 		InputAttestations:  inputAttestations,
 		VerificationResult: verificationResult(passed),


### PR DESCRIPTION
BREAKING CHANGE:

Allows policy bundle to be retrieved from any unauthenticated HTTP location, or relative path to an already existing bundle locally. Removes no longer used `policy-version` flag.