### PR TITLE
feat: support downloading policy from GitHub tree URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The following process is used to create a VSA:
 
 `--policy-url`: Location of policy bundle that will be used to determine VSA result.
 Supports http(s) urls for unauthenticated external downloads.
-Absolute and relative paths can be used for an existing, local bundle.
+Absolute and relative paths can be used for an existing, local bundle or directory.
+It's also possible to download files from a particular GitHub commit
 
 Examples:
 
@@ -128,6 +129,8 @@ Examples:
 - `bundle.tar.gz`
 - `../bundle.tar.gz`
 - `/Users/myhome/bundle.tar.gz`
+- `../policy`
+- `https://github.com/liatrio/gh-trusted-builds-policy/tree/ef3194db6ca9a7a4b030686e4669c45db360a0c2/policy`
 
 `--signer-identities-query`: A Rego query that should specify the expected attestation signer identities. The result should be a list of objects that can be unmarshalled into `cosign.Identity`. Defaults to `data.governance.signer_identities`.
 

--- a/cmd/vsa.go
+++ b/cmd/vsa.go
@@ -13,6 +13,8 @@ func VsaCmd() *cobra.Command {
 		Use:   "vsa",
 		Short: "Creates a SLSA verification summary attestation by evaluating an artifact against an OPA policy",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.GetTokenFromEnv()
+
 			return vsa.Attest(opts)
 		},
 	}

--- a/internal/config/vsa.go
+++ b/internal/config/vsa.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/spf13/cobra"
+	"os"
 )
 
 type VsaCommandOptions struct {
@@ -11,6 +12,7 @@ type VsaCommandOptions struct {
 	Debug                 bool
 	SignerIdentitiesQuery string
 	PolicyQuery           string
+	GitHubToken           string
 }
 
 func NewVsaCommandOptions() *VsaCommandOptions {
@@ -32,4 +34,8 @@ func (vsa *VsaCommandOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&vsa.Debug, "debug", false, "Emit debug logs from policy evaluation")
 
 	vsa.GlobalOptions.AddFlags(cmd)
+}
+
+func (vsa *VsaCommandOptions) GetTokenFromEnv() {
+	vsa.GitHubToken = os.Getenv("GITHUB_TOKEN")
 }


### PR DESCRIPTION
Adds the ability to pull a policy bundle from a GitHub tree URL, which will help with testing policy changes as well as one-off changes for manual testing.